### PR TITLE
Update number of days to check for new feeds to 14

### DIFF
--- a/.github/workflows/feed_bot.yml
+++ b/.github/workflows/feed_bot.yml
@@ -9,7 +9,7 @@ on:
       days:
         description: "Number of days before today to check for new feeds"
         required: false
-        default: "5"
+        default: "14"
 
 jobs:
   feed-bot:
@@ -44,5 +44,5 @@ jobs:
         env:
           GALAXY_SOCIAL_BOT_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPO: "usegalaxy-eu/galaxy-social"
-          DAYS: ${{ github.event.inputs.days || '5' }}
+          DAYS: ${{ github.event.inputs.days || '14' }}
         run: python -u app/feed_bot.py


### PR DESCRIPTION
This pull request updates the number of days to check for new feeds from 5 to 14. This change ensures that the feed bot will check for new feeds within a longer time frame.